### PR TITLE
Fixed full buffer at the start

### DIFF
--- a/libs/circular_buffer.h
+++ b/libs/circular_buffer.h
@@ -10,9 +10,7 @@ namespace support
     public:
         CircularBuffer (size_t capacity) :
             _capacity(capacity)
-            , _buffer_inner(capacity)
         {
-
         }
         /**
          * @brief Add an item to the buffer


### PR DESCRIPTION
Deque constructor with int fills the container